### PR TITLE
Fix for wrap-guide

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -27,7 +27,7 @@ atom-text-editor,
   }
 
   .wrap-guide {
-    opacity: 0;
+    background-color: @nova_decoration_medium;
   }
 
   .cursor {


### PR DESCRIPTION
Removes the opacity:0 on the wrap-guide and sets the background color to novaColors.decoration.medium.